### PR TITLE
Avoid losing an SMTP error due to ConnectionLost

### DIFF
--- a/slimta/relay/smtp/client.py
+++ b/slimta/relay/smtp/client.py
@@ -148,14 +148,14 @@ class SmtpRelayClient(Greenlet):
             if data and not data.is_error():
                 with Timeout(self.data_timeout):
                     self.client.send_empty_data()
-            self._rset()
             result.set_exception(e)
+            self._rset()
             return False
         try:
             self._send_message_data(envelope)
         except SmtpRelayError as e:
-            self._rset()
             result.set_exception(e)
+            self._rset()
             return False
         return True
 


### PR DESCRIPTION
First of all, this is a great project, thank you!

I haven't read fully through the code yet, so forgive me if there's a better way to do this, or if I'm just missing something obvious.

I found that SMTPRelayClient instances were failing due to ConnectionLost without raising the actual SMTP error. Upon further inspection, it seems that since self._rset is ran before adding the original exception to the result, it can cause an exception therefore bypassing result.set_exception(e).

I believe there may be at least one more case like this, I'll update in a bit!
