### PR TITLE
Allow relay to return the Reply of a delivered msg

### DIFF
--- a/slimta/queue/__init__.py
+++ b/slimta/queue/__init__.py
@@ -397,7 +397,7 @@ class Queue(Greenlet):
         permfails = []
         for i, rcpt in enumerate(envelope.recipients):
             rcpt_res = results[i]
-            if not rcpt_res:
+            if rcpt_res is None or isinstance(rcpt_res, Reply):
                 delivered.append(i)
             elif isinstance(rcpt_res, PermanentRelayError):
                 delivered.append(i)

--- a/slimta/relay/__init__.py
+++ b/slimta/relay/__init__.py
@@ -100,9 +100,10 @@ class Relay(object):
         Implementations may return ``None`` or raise a :class:`RelayError` to
         apply the result to all recipients in the envelope. Alternatively, they
         may return an iterable where each item corresponds to
-        :attr:`~slimta.envelope.Envelope.recipients` and is ``None`` on
-        successful delivery, or an instance of :class:`PermanentRelayError` or
-        :class:`TransientRelayError` on failure.
+        :attr:`~slimta.envelope.Envelope.recipients` and is either ``None`` or
+        a :class:`~slimta.smtp.reply.Reply` on successful delivery, or an instance of
+        :class:`PermanentRelayError` or :class:`TransientRelayError` on
+        failure.
 
         :param envelope: |Envelope| to attempt delivery for.
         :param attempts: Number of times the envelope has attempted delivery.

--- a/slimta/relay/smtp/client.py
+++ b/slimta/relay/smtp/client.py
@@ -186,11 +186,14 @@ class SmtpRelayClient(RelayPoolClient):
         try:
             self._handle_encoding(envelope)
             self._send_envelope(rcpt_results, envelope)
-            self._send_message_data(envelope)
+            msg_result = self._send_message_data(envelope)
         except SmtpRelayError as e:
             result.set_exception(e)
             self._rset()
         else:
+            rcpt_results = [
+                i if i is not None else msg_result
+                for i in rcpt_results]
             result.set(rcpt_results)
 
     def _check_server_timeout(self):

--- a/test/test_slimta_relay_smtp_client.py
+++ b/test/test_slimta_relay_smtp_client.py
@@ -10,6 +10,7 @@ from pysasl.plain import PlainMechanism
 
 from slimta.util.deque import BlockingDeque
 from slimta.smtp import ConnectionLost, SmtpError
+from slimta.smtp.reply import Reply
 from slimta.relay import TransientRelayError, PermanentRelayError
 from slimta.relay.smtp.client import SmtpRelayClient
 from slimta.envelope import Envelope
@@ -221,7 +222,7 @@ class TestSmtpRelayClient(unittest.TestCase, MoxTestBase):
         client._connect()
         client._ehlo()
         client._deliver(result, env)
-        self.assertEqual([None], result.get_nowait())
+        self.assertEqual([Reply('250', 'Ok')], result.get_nowait())
 
     def test_deliver_badpipeline(self):
         result = AsyncResult()
@@ -313,7 +314,7 @@ class TestSmtpRelayClient(unittest.TestCase, MoxTestBase):
         client._connect()
         client._ehlo()
         client._deliver(result, env)
-        self.assertEqual([None], result.get_nowait())
+        self.assertEqual([Reply('250', 'Ok')], result.get_nowait())
 
     def test_deliver_conversion_failure(self):
         result = AsyncResult()
@@ -368,7 +369,7 @@ class TestSmtpRelayClient(unittest.TestCase, MoxTestBase):
         self.mox.ReplayAll()
         client = SmtpRelayClient(None, queue, socket_creator=self._socket_creator, ehlo_as='test')
         client._run()
-        self.assertEqual([None], result.get_nowait())
+        self.assertEqual([Reply('250', 'Ok')], result.get_nowait())
 
     def test_run_multiple(self):
         result1 = AsyncResult()
@@ -397,8 +398,8 @@ class TestSmtpRelayClient(unittest.TestCase, MoxTestBase):
         self.mox.ReplayAll()
         client = SmtpRelayClient(None, queue, socket_creator=self._socket_creator, ehlo_as='test', idle_timeout=0.0)
         client._run()
-        self.assertEqual([None], result1.get_nowait())
-        self.assertEqual([None], result2.get_nowait())
+        self.assertEqual([Reply('250', 'Ok')], result1.get_nowait())
+        self.assertEqual([Reply('250', 'Ok')], result2.get_nowait())
 
     def test_run_random_exception(self):
         result = AsyncResult()


### PR DESCRIPTION
Goal is to be able to bring the Reply message up to the queue if it wants to do
something with it.

This change is backward compatible.