### PR TITLE
Fix WSGI based on PEP-3333

### DIFF
--- a/slimta/logging/http.py
+++ b/slimta/logging/http.py
@@ -24,10 +24,9 @@ responses as well as more general HTTP logs.
 
 """
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 from functools import partial
-
 
 __all__ = ['HttpLogger']
 
@@ -43,24 +42,24 @@ class HttpLogger(object):
 
     def __init__(self, log):
         from slimta.logging import logline
-        self.log = partial(logline, log.debug, str('http'))
+        self.log = partial(logline, log.debug, 'http')
 
     def _get_method_from_environ(self, environ):
-        return environ[str('REQUEST_METHOD')].upper()
+        return environ['REQUEST_METHOD'].upper()
 
     def _get_path_from_environ(self, environ):
-        return environ.get(str('PATH_INFO'), None)
+        return environ.get('PATH_INFO', None)
 
     def _get_headers_from_environ(self, environ):
         ret = []
         for key, value in environ.items():
-            if key == str('CONTENT_TYPE'):
-                ret.append((str('Content-Type'), value))
-            elif key == str('CONTENT_LENGTH'):
-                ret.append((str('Content-Length'), value))
-            elif key.startswith(str('HTTP_')):
-                parts = key.split(str('_'))
-                name = str('-').join([part.capitalize() for part in parts[1:]])
+            if key == 'CONTENT_TYPE':
+                ret.append(('Content-Type', value))
+            elif key == 'CONTENT_LENGTH':
+                ret.append(('Content-Length', value))
+            elif key.startswith('HTTP_'):
+                parts = key.split('_')
+                name = '-'.join([part.capitalize() for part in parts[1:]])
                 ret.append((name, value))
         return ret
 

--- a/test/test_slimta_logging_http.py
+++ b/test/test_slimta_logging_http.py
@@ -1,86 +1,55 @@
-from __future__ import unicode_literals
 
-import unittest2 as unittest
-import six
+import unittest
 
 from testfixtures import log_capture
 
 from slimta.logging import getHttpLogger
 
 
-def native_dict(d):
-    """ Converts dict keys/values to native strings
-
-    (which is unicode for py3 and bytes for py2)
-
-    """
-    return {str(k): str(v) for k, v in d.items()}
-
-
 class TestHttpLogger(unittest.TestCase):
 
     def setUp(self):
         self.log = getHttpLogger('test')
-        self.environ = native_dict({
-            'REQUEST_METHOD': 'GET',
-            'PATH_INFO': '/test/stuff',
-            'HTTP_HEADER': 'value'
-        })
+        self.environ = {'REQUEST_METHOD': 'GET',
+                        'PATH_INFO': '/test/stuff',
+                        'HTTP_HEADER': 'value'}
         self.conn = {}
 
     @log_capture()
     def test_wsgi_request(self, l):
-        environ1 = native_dict({
-            'REQUEST_METHOD': 'GET',
-            'PATH_INFO': '/test/stuff',
-            'CONTENT_LENGTH': 'value'
-        })
-        environ2 = native_dict({
-            'REQUEST_METHOD': 'GET',
-            'PATH_INFO': '/test/stuff',
-            'CONTENT_TYPE': 'value'
-        })
-        environ3 = native_dict({
-            'REQUEST_METHOD': 'GET',
-            'PATH_INFO': '/test/stuff',
-            'HTTP_X_HEADER_NAME': 'value'
-        })
+        environ1 = {'REQUEST_METHOD': 'GET',
+                    'PATH_INFO': '/test/stuff',
+                    'CONTENT_LENGTH': 'value'}
+        environ2 = {'REQUEST_METHOD': 'GET',
+                    'PATH_INFO': '/test/stuff',
+                    'CONTENT_TYPE': 'value'}
+        environ3 = {'REQUEST_METHOD': 'GET',
+                    'PATH_INFO': '/test/stuff',
+                    'HTTP_X_HEADER_NAME': 'value'}
         self.log.wsgi_request(environ1)
         self.log.wsgi_request(environ2)
         self.log.wsgi_request(environ3)
-        l.check((str('test'), str('DEBUG'), u'http:{0}:server_request headers=[(\'Content-Length\', \'value\')] method=\'GET\' path=\'/test/stuff\''.format(id(environ1))),
-                    (str('test'), str('DEBUG'), u'http:{0}:server_request headers=[(\'Content-Type\', \'value\')] method=\'GET\' path=\'/test/stuff\''.format(id(environ2))),
-                    (str('test'), str('DEBUG'), u'http:{0}:server_request headers=[(\'X-Header-Name\', \'value\')] method=\'GET\' path=\'/test/stuff\''.format(id(environ3))))
+        l.check(('test', 'DEBUG', 'http:{0}:server_request headers=[(\'Content-Length\', \'value\')] method=\'GET\' path=\'/test/stuff\''.format(id(environ1))),
+                ('test', 'DEBUG', 'http:{0}:server_request headers=[(\'Content-Type\', \'value\')] method=\'GET\' path=\'/test/stuff\''.format(id(environ2))),
+                ('test', 'DEBUG', 'http:{0}:server_request headers=[(\'X-Header-Name\', \'value\')] method=\'GET\' path=\'/test/stuff\''.format(id(environ3))))
 
     @log_capture()
     def test_wsgi_response(self, l):
-        environ = native_dict({
-            'REQUEST_METHOD': 'GET',
-            'PATH_INFO': '/test/stuff',
-            'HTTP_HEADER': 'value'
-        })
-        self.log.wsgi_response(environ, '200 OK', [(b'Header', b'value')])
-        if six.PY2:
-            l.check((b'test', b'DEBUG', 'http:{0}:server_response headers=[(\'Header\', \'value\')] status=u\'200 OK\''.format(id(environ))))
-        else:
-            l.check(('test', 'DEBUG', 'http:{0}:server_response headers=[(b\'Header\', b\'value\')] status=\'200 OK\''.format(id(environ))))
-
+        environ = {'REQUEST_METHOD': 'GET',
+                   'PATH_INFO': '/test/stuff',
+                   'HTTP_HEADER': 'value'}
+        self.log.wsgi_response(environ, '200 OK', [('Header', 'value')])
+        l.check(('test', 'DEBUG', 'http:{0}:server_response headers=[(\'Header\', \'value\')] status=\'200 OK\''.format(id(environ))))
 
     @log_capture()
     def test_request(self, l):
-        self.log.request(self.conn, 'GET', '/test/stuff', [(b'Header', b'value')])
-        if six.PY2:
-            l.check(('test', 'DEBUG', 'http:{0}:client_request headers=[(\'Header\', \'value\')] method=u\'GET\' path=u\'/test/stuff\''.format(id(self.conn))))
-        else:
-            l.check(('test', 'DEBUG', 'http:{0}:client_request headers=[(b\'Header\', b\'value\')] method=\'GET\' path=\'/test/stuff\''.format(id(self.conn))))
+        self.log.request(self.conn, 'GET', '/test/stuff', [('Header', 'value')])
+        l.check(('test', 'DEBUG', 'http:{0}:client_request headers=[(\'Header\', \'value\')] method=\'GET\' path=\'/test/stuff\''.format(id(self.conn))))
 
     @log_capture()
     def test_response(self, l):
-        self.log.response(self.conn, '200 OK', [(b'Header', b'value')])
-        if six.PY2:
-            l.check(('test', 'DEBUG', 'http:{0}:client_response headers=[(\'Header\', \'value\')] status=u\'200 OK\''.format(id(self.conn))))
-        else:
-            l.check(('test', 'DEBUG', 'http:{0}:client_response headers=[(b\'Header\', b\'value\')] status=\'200 OK\''.format(id(self.conn))))
+        self.log.response(self.conn, '200 OK', [('Header', 'value')])
+        l.check(('test', 'DEBUG', 'http:{0}:client_response headers=[(\'Header\', \'value\')] status=\'200 OK\''.format(id(self.conn))))
 
 
 # vim:et:fdm=marker:sts=4:sw=4:ts=4


### PR DESCRIPTION
This PR is a revert of much of the changes to the `wsgi` modules from #34. [PEP-3333 "Unicode Issues"](https://www.python.org/dev/peps/pep-3333/#unicode-issues) states that WSGI servers will always be passing in `str`, in both Py2 and Py3.

I ran the previous code from #34 through `gevent.pywsgi` and it failed, as it was not expecting the `environ` to include bytestrings. This version works correctly when served with `gevent.pywsgi`.