### PR TITLE
Remove threading monkey-patching

### DIFF
--- a/slimta/util/__init__.py
+++ b/slimta/util/__init__.py
@@ -59,7 +59,9 @@ def monkeypatch_all(*args, **kwds):
                 setattr(before[mod][0], k, v)
 
 
-with monkeypatch_all():
+with monkeypatch_all(
+        socket=True, dns=True, time=True, select=True, thread=False,
+        os=True, ssl=True, httplib=False, aggressive=True):
     import dns.resolver
 
 #: .. versionadded:: 0.3.19


### PR DESCRIPTION
It prevented Django test runner & dev server to work. It's fairly reasonable
to think that it also impacts other libs using threading internally.

The thing is monkey-patching is supposed to be "scopped" to dnspython, but this
approach is not thread-safe seems to have side effects with multi-threaded
code.

From my tests this patch do not prevent any functioning of DNS-related features
of slimta.

The downside is some dnspython features (not used in slimta) may behave
unexpectedly (namely, the crypto-related features, that make use of threading
library).

fix #43