### PR TITLE
Return a temporary error on queuing problem

### DIFF
--- a/slimta/edge/smtp.py
+++ b/slimta/edge/smtp.py
@@ -182,8 +182,8 @@ class SmtpSession(object):
 
         results = self.handoff(self.envelope)
         if isinstance(results[0][1], QueueError):
-            reply.code = '550'
-            reply.message = '5.6.0 Error queuing message'
+            reply.code = '451'
+            reply.message = '4.7.0 Error queuing message'
         elif isinstance(results[0][1], RelayError):
             relay_reply = results[0][1].reply
             reply.copy(relay_reply)

--- a/slimta/edge/smtp.py
+++ b/slimta/edge/smtp.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import
 
 from slimta.envelope import Envelope
 from slimta.smtp.server import Server
+from slimta.smtp.reply import Reply
 from slimta.smtp import ConnectionLost, MessageTooBig
 from slimta.queue import QueueError
 from slimta.relay import RelayError
@@ -182,8 +183,9 @@ class SmtpSession(object):
 
         results = self.handoff(self.envelope)
         if isinstance(results[0][1], QueueError):
-            reply.code = '451'
-            reply.message = '4.7.0 Error queuing message'
+            default_reply = Reply('451', '4.3.0 Error queuing message')
+            queue_reply = getattr(results[0][1], 'reply', default_reply)
+            reply.copy(queue_reply)
         elif isinstance(results[0][1], RelayError):
             relay_reply = results[0][1].reply
             reply.copy(relay_reply)

--- a/slimta/edge/wsgi.py
+++ b/slimta/edge/wsgi.py
@@ -248,7 +248,7 @@ class WsgiEdge(Edge, WsgiServer):
     def _enqueue_envelope(self, env):
         results = self.handoff(env)
         if isinstance(results[0][1], QueueError):
-            reply = Reply('550', '5.6.0 Error queuing message')
+            reply = Reply('451', '4.7.0 Error queuing message')
             raise _build_http_response(reply)
         elif isinstance(results[0][1], RelayError):
             relay_reply = results[0][1].reply

--- a/slimta/edge/wsgi.py
+++ b/slimta/edge/wsgi.py
@@ -248,7 +248,8 @@ class WsgiEdge(Edge, WsgiServer):
     def _enqueue_envelope(self, env):
         results = self.handoff(env)
         if isinstance(results[0][1], QueueError):
-            reply = Reply('451', '4.7.0 Error queuing message')
+            default_reply = Reply('451', '4.3.0 Error queuing message')
+            reply = getattr(results[0][1], 'reply', default_reply)
             raise _build_http_response(reply)
         elif isinstance(results[0][1], RelayError):
             relay_reply = results[0][1].reply

--- a/test/test_slimta_edge_smtp.py
+++ b/test/test_slimta_edge_smtp.py
@@ -113,7 +113,7 @@ class TestEdgeSmtp(unittest.TestCase, MoxTestBase):
         reply = Reply('250')
         h.HAVE_DATA(reply, b'', None)
         self.assertEqual('451', reply.code)
-        self.assertEqual('4.7.0 Error queuing message', reply.message)
+        self.assertEqual('4.3.0 Error queuing message', reply.message)
 
     def test_smtp_edge(self):
         queue = self.mox.CreateMockAnything()

--- a/test/test_slimta_edge_smtp.py
+++ b/test/test_slimta_edge_smtp.py
@@ -112,8 +112,8 @@ class TestEdgeSmtp(unittest.TestCase, MoxTestBase):
         h.envelope = env
         reply = Reply('250')
         h.HAVE_DATA(reply, b'', None)
-        self.assertEqual('550', reply.code)
-        self.assertEqual('5.6.0 Error queuing message', reply.message)
+        self.assertEqual('451', reply.code)
+        self.assertEqual('4.7.0 Error queuing message', reply.message)
 
     def test_smtp_edge(self):
         queue = self.mox.CreateMockAnything()

--- a/test/test_slimta_edge_wsgi.py
+++ b/test/test_slimta_edge_wsgi.py
@@ -73,7 +73,7 @@ class TestEdgeWsgi(MoxTestBase):
 
     def test_queueerror(self):
         self.queue.enqueue(IsA(Envelope)).AndReturn([(Envelope(), QueueError())])
-        self.start_response.__call__('500 Internal Server Error', IsA(list))
+        self.start_response.__call__('503 Service Unavailable', IsA(list))
         self.mox.ReplayAll()
         w = WsgiEdge(self.queue)
         self.assertEqual([], w(self.environ, self.start_response))


### PR DESCRIPTION
I believe a queuing problem (on slimta's end) should not return a permanent error but should softbounce instead, so that the delivery is retried later.

Let me know if you want me to tune the error code, I wasn't quite sure about the 4.7.0