### PR TITLE
Add exc_info to logging.log_exception

### DIFF
--- a/slimta/edge/wsgi.py
+++ b/slimta/edge/wsgi.py
@@ -61,7 +61,7 @@ import re
 from base64 import b64decode
 from wsgiref.headers import Headers
 
-from slimta.logging import log_exception
+from slimta import logging
 from slimta.http.wsgi import WsgiServer
 from slimta.envelope import Envelope
 from slimta.smtp.reply import Reply
@@ -169,7 +169,7 @@ class WsgiEdge(Edge, WsgiServer):
             start_response(res.status, res.headers)
             return res.data
         except Exception as exc:
-            log_exception(__name__)
+            logging.log_exception(__name__)
             msg = '{0!s}\n'.format(exc)
             content_length = str(len(msg))
             headers = [('Content-Length', content_length),

--- a/slimta/queue/__init__.py
+++ b/slimta/queue/__init__.py
@@ -44,7 +44,7 @@ from gevent.event import Event
 from gevent.lock import Semaphore
 from gevent.pool import Pool
 
-from slimta.logging import log_exception
+from slimta import logging
 from slimta.core import SlimtaError
 from slimta.relay import PermanentRelayError, TransientRelayError
 from slimta.smtp.reply import Reply
@@ -393,7 +393,7 @@ class Queue(Greenlet):
         except PermanentRelayError as e:
             self._perm_fail(id, envelope, e.reply)
         except Exception as e:
-            log_exception(__name__)
+            logging.log_exception(__name__)
             reply = Reply('450', '4.0.0 Unhandled delivery error: '+str(e))
             self._pool_spawn('store', self._retry_later, id, envelope, reply)
             raise

--- a/slimta/relay/smtp/mx.py
+++ b/slimta/relay/smtp/mx.py
@@ -33,7 +33,7 @@ import time
 
 from pycares.errno import ARES_ENOTFOUND, ARES_ENODATA
 
-from slimta.logging import log_exception
+from slimta import logging
 from slimta.smtp.reply import Reply
 from slimta.util import validate_tls
 from slimta.util.dns import DNSResolver, DNSError
@@ -225,7 +225,7 @@ class MxSmtpRelay(Relay):
                 reply = Reply('550', '5.1.2 '+msg)
                 raise PermanentRelayError(msg, reply)
             except DNSError:
-                log_exception(__name__)
+                logging.log_exception(__name__)
                 msg = 'DNS lookup failed'
                 reply = Reply('451', '4.4.3 '+msg)
                 raise TransientRelayError(msg, reply)

--- a/slimta/util/dns.py
+++ b/slimta/util/dns.py
@@ -33,7 +33,7 @@ import gevent
 from gevent import select
 from gevent.event import AsyncResult
 
-from slimta.logging import log_exception
+from slimta import logging
 
 __all__ = ['DNSError', 'DNSResolver']
 
@@ -125,7 +125,7 @@ class DNSResolver(object):
                 for fd in wlist:
                     cls._channel.process_fd(pycares.ARES_SOCKET_BAD, fd)
         except Exception:
-            log_exception(__name__)
+            logging.log_exception(__name__)
             cls._channel.cancel()
             cls._channel = None
             raise


### PR DESCRIPTION
In order to give maximum relevant information to logger, we could add `exc_info` to `logger.error`. Then full exception is propagate

NB: _This is very relevant for Sentry_.