### PR TITLE
Fix dequeue race condition

### DIFF
--- a/slimta/queue/__init__.py
+++ b/slimta/queue/__init__.py
@@ -438,8 +438,9 @@ class Queue(Greenlet):
             envelope, attempts = self.store.get(id)
         except KeyError:
             return
-        self.active_ids.add(id)
-        self._pool_spawn('relay', self._attempt, id, envelope, attempts)
+        if id not in self.active_ids:
+            self.active_ids.add(id)
+            self._pool_spawn('relay', self._attempt, id, envelope, attempts)
 
     def _check_ready(self, now):
         last_i = 0


### PR DESCRIPTION
Ran into this with redis storage:

the queue check loop initiated in _run() catches queued envelopes while they're being handled in enqueue().
This causes 2 relay._attempt() to be called and 2 actual deliveries.

This patch simply checks if the ID to be dequeued already exists in active_ids, which means it's being handled already.

Let me know if you see any case where it might break.