### PR TITLE
Fix pool parameter boolean condition for EdgeServer

### DIFF
--- a/slimta/edge/__init__.py
+++ b/slimta/edge/__init__.py
@@ -118,7 +118,7 @@ class EdgeServer(Edge, gevent.Greenlet):
 
     def __init__(self, listener, queue, pool=None, hostname=None):
         super(EdgeServer, self).__init__(queue, hostname)
-        spawn = pool or 'default'
+        spawn = 'default' if pool is None else pool
         self.server = StreamServer(listener, self._handle, spawn=spawn)
 
     def _handle(self, socket, address):


### PR DESCRIPTION
If I set a `gevent.pool.Pool` as a pool (with no size) for an `SmtpEdge` for example, this boolean condition will always return `'default'` instead of using my `Pool`.

This is because of `Pool.__len__` which return how many greenlets this `Pool` is tracking.