### PR TITLE
Always TLS unless explicitly told not to.

### DIFF
--- a/slimta/edge/smtp.py
+++ b/slimta/edge/smtp.py
@@ -33,6 +33,7 @@ from slimta.smtp import ConnectionLost, MessageTooBig
 from slimta.queue import QueueError
 from slimta.relay import RelayError
 from slimta.util.ptrlookup import PtrLookup
+from slimta.util import validate_tls
 from . import EdgeServer
 
 __all__ = ['SmtpEdge', 'SmtpValidators']
@@ -212,7 +213,8 @@ class SmtpEdge(EdgeServer):
                  also be given as a list of SASL mechanism names to support,
                  e.g. ``['PLAIN', 'LOGIN', 'CRAM-MD5']``.
     :param tls: Optional dictionary of TLS settings passed directly as
-                keyword arguments to :class:`gevent.ssl.SSLSocket`.
+                keyword arguments to :class:`gevent.ssl.SSLSocket`. ``False``
+                will explicitly disable TLS.
     :param tls_immediately: If True, connections will be encrypted
                             immediately before the SMTP banner.
     :param command_timeout: Seconds before the connection times out waiting
@@ -236,7 +238,7 @@ class SmtpEdge(EdgeServer):
         self.data_timeout = data_timeout
         self.validator_class = validator_class
         self.auth = auth
-        self.tls = tls
+        self.tls = validate_tls(tls)
         self.tls_immediately = tls_immediately
 
     def handle(self, socket, address):

--- a/slimta/http/wsgi.py
+++ b/slimta/http/wsgi.py
@@ -33,6 +33,7 @@ import sys
 
 from gevent.pywsgi import WSGIServer as GeventWSGIServer
 
+from slimta.util import validate_tls
 from slimta import logging
 
 __all__ = ['WsgiServer']
@@ -59,11 +60,12 @@ class WsgiServer(object):
                      use for new greenlets.
         :param tls: Optional dictionary of TLS settings passed directly as
                     keyword arguments to :class:`gevent.ssl.SSLSocket`.
+                    ``False`` will explicitly disable TLS.
         :rtype: :class:`gevent.pywsgi.WSGIServer`
 
         """
         spawn = pool or 'default'
-        tls = tls or {}
+        tls = validate_tls(tls)
         return GeventWSGIServer(listener, self, log=sys.stdout, spawn=spawn,
                                 **tls)
 

--- a/slimta/relay/http.py
+++ b/slimta/relay/http.py
@@ -174,8 +174,8 @@ class HttpRelay(RelayPool):
                       to the destination. If this limit is reached and no
                       connections are idle, new attempts will block.
     :param tls: Dictionary of TLS settings passed directly as keyword arguments
-                to :class:`gevent.ssl.SSLSocket`. This parameter is optional
-                unless ``https:`` is given in ``url``.
+                to :class:`gevent.ssl.SSLSocket`. ``False`` will explicitly
+                disable TLS.
     :param ehlo_as: The string to send as the EHLO string in a header. Defaults
                     to the FQDN of the system. This may also be given as a
                     function that will be executed with no arguments at the

--- a/slimta/relay/smtp/client.py
+++ b/slimta/relay/smtp/client.py
@@ -136,11 +136,11 @@ class SmtpRelayClient(RelayPoolClient):
             raise SmtpRelayError.factory(auth)
 
     def _handshake(self):
-        if self.tls and self.tls_immediately:
+        if self.tls is not False and self.tls_immediately:
             self.client.encrypt(self.tls)
         self._banner()
         self._ehlo()
-        if self.tls and not self.tls_immediately:
+        if self.tls is not False and not self.client.io.encrypted:
             if self.tls_required or 'STARTTLS' in self.client.extensions:
                 self._starttls()
                 self._ehlo()

--- a/slimta/relay/smtp/mx.py
+++ b/slimta/relay/smtp/mx.py
@@ -128,7 +128,8 @@ class MxSmtpRelay(Relay):
     All arguments are optional.
 
     :param tls: Optional dictionary of TLS settings passed directly as
-                keyword arguments to :class:`gevent.ssl.SSLSocket`.
+                keyword arguments to :class:`gevent.ssl.SSLSocket`. ``False``
+                will explicitly disable TLS.
     :param tls_required: If given and True, it should be considered a delivery
                          failure if TLS cannot be negotiated by the client.
     :param connect_timeout: Timeout in seconds to wait for a client connection

--- a/slimta/relay/smtp/static.py
+++ b/slimta/relay/smtp/static.py
@@ -46,7 +46,8 @@ class StaticSmtpRelay(RelayPool):
                       to the destination. If this limit is reached and no
                       connections are idle, new attempts will block.
     :param tls: Optional dictionary of TLS settings passed directly as
-                keyword arguments to :class:`gevent.ssl.SSLSocket`.
+                keyword arguments to :class:`gevent.ssl.SSLSocket`. ``False``
+                will explicitly disable TLS.
     :param tls_required: If given and True, it should be considered a delivery
                          failure if TLS cannot be negotiated by the client.
     :param connect_timeout: Timeout in seconds to wait for a client connection

--- a/slimta/util/__init__.py
+++ b/slimta/util/__init__.py
@@ -43,13 +43,15 @@ def validate_tls(tls, **overrides):
     :raises: OSError
 
     """
-    if not tls:
+    if tls is False:
         return tls
+    elif tls is None or tls is True:
+        return {}
     tls_copy = tls.copy()
+    tls_copy.update(overrides)
     for arg in ('keyfile', 'certfile', 'ca_certs'):
         if arg in tls_copy:
             open(tls_copy[arg], 'r').close()
-    tls_copy.update(overrides)
     return tls_copy
 
 

--- a/test/test_slimta_smtp_server.py
+++ b/test/test_slimta_smtp_server.py
@@ -17,7 +17,7 @@ class TestSmtpServer(unittest.TestCase, MoxTestBase):
         self.tls_args = {'server_side': True}
 
     def test_starttls_extension(self):
-        s = Server(None, None)
+        s = Server(None, None, tls=False)
         self.assertFalse('STARTTLS' in s.extensions)
         s = Server(None, None, tls=self.tls_args, tls_immediately=False)
         self.assertTrue('STARTTLS' in s.extensions)
@@ -385,7 +385,7 @@ class TestSmtpServer(unittest.TestCase, MoxTestBase):
         self.sock.recv(IsA(int)).AndReturn(b'QUIT\r\n')
         self.sock.sendall(b'221 2.0.0 Bye\r\n')
         self.mox.ReplayAll()
-        s = Server(self.sock, None)
+        s = Server(self.sock, None, tls=False)
         s.handle()
 
     def test_gather_params(self):


### PR DESCRIPTION
Modern wisdom says to TLS whenever possible, so it _should_ be default behavior. This change switches the behavior of the default `tls=None` to use TLS when available, and allows `tls=False` to explicitly disable TLS support. The argument may still be a dictionary to override TLS settings, such as specifying key and certificate files.

Fix #87 