### PR TITLE
Fix enqueue race condition.

### DIFF
--- a/slimta/queue/__init__.py
+++ b/slimta/queue/__init__.py
@@ -328,7 +328,7 @@ class Queue(Greenlet):
         results = list(zip(envelopes, ids))
         for env, id in results:
             if not isinstance(id, BaseException):
-                if self.relay:
+                if self.relay and id not in self.active_ids:
                     self.active_ids.add(id)
                     self._pool_spawn('relay', self._attempt, id, env, 0)
             elif not isinstance(id, QueueError):


### PR DESCRIPTION
Sometimes emails in the queue will already have been processed before the first attempt here.

I discovered this when our full integration test was showing duplicate emails sent. This fixed the issue.  

This is basically the same issue as https://github.com/slimta/python-slimta/pull/94