### PR TITLE
Cannot TLS on server-side without certfile

### DIFF
--- a/slimta/edge/smtp.py
+++ b/slimta/edge/smtp.py
@@ -213,8 +213,7 @@ class SmtpEdge(EdgeServer):
                  also be given as a list of SASL mechanism names to support,
                  e.g. ``['PLAIN', 'LOGIN', 'CRAM-MD5']``.
     :param tls: Optional dictionary of TLS settings passed directly as
-                keyword arguments to :class:`gevent.ssl.SSLSocket`. ``False``
-                will explicitly disable TLS.
+                keyword arguments to :class:`gevent.ssl.SSLSocket`.
     :param tls_immediately: If True, connections will be encrypted
                             immediately before the SMTP banner.
     :param command_timeout: Seconds before the connection times out waiting

--- a/slimta/http/wsgi.py
+++ b/slimta/http/wsgi.py
@@ -60,7 +60,6 @@ class WsgiServer(object):
                      use for new greenlets.
         :param tls: Optional dictionary of TLS settings passed directly as
                     keyword arguments to :class:`gevent.ssl.SSLSocket`.
-                    ``False`` will explicitly disable TLS.
         :rtype: :class:`gevent.pywsgi.WSGIServer`
 
         """

--- a/slimta/smtp/server.py
+++ b/slimta/smtp/server.py
@@ -80,15 +80,14 @@ class Server(object):
                  also be given as a list of SASL mechanism names to support,
                  e.g. ``['PLAIN', 'LOGIN', 'CRAM-MD5']``.
     :param tls: Optional dictionary of TLS settings passed directly as
-                keyword arguments to :class:`gevent.ssl.SSLSocket`. ``False``
-                will explicitly disable TLS.
+                keyword arguments to :class:`gevent.ssl.SSLSocket`.
     :param tls_immediately: If True, the socket will be encrypted
                             immediately.
+    :type tls_immediately: True or False
     :param tls_wrapper: Optional function that takes a socket and the ``tls``
                         dictionary, creates a new encrypted socket, performs
                         the TLS handshake, and returns it. The default uses
                         :class:`~gevent.ssl.SSLSocket`.
-    :type tls_immediately: True or False
     :param command_timeout: Optional timeout waiting for a command to be
                             sent from the client.
     :param data_timeout: Optional timeout waiting for data to be sent from
@@ -117,7 +116,7 @@ class Server(object):
         self.extensions.add('PIPELINING')
         self.extensions.add('ENHANCEDSTATUSCODES')
         self.extensions.add('SMTPUTF8')
-        if self.tls is not False and not tls_immediately:
+        if self.tls and not tls_immediately:
             self.extensions.add('STARTTLS')
         if auth:
             if isinstance(auth, list):
@@ -191,7 +190,7 @@ class Server(object):
         :raises: :class:`~slimta.smtp.ConnectionLost` or unhandled exceptions.
 
         """
-        if self.tls is not False and self.tls_immediately:
+        if self.tls and self.tls_immediately:
             if not self._encrypt_session():
                 tls_failure.send(self.io, flush=True)
                 return

--- a/test/test_slimta_util_deque.py
+++ b/test/test_slimta_util_deque.py
@@ -12,7 +12,7 @@ class TestBlockingDeque(unittest.TestCase, MoxTestBase):
     def setUp(self):
         super(TestBlockingDeque, self).setUp()
         self.deque = BlockingDeque()
-        self.deque.sema = self.mox.CreateMock(Semaphore)
+        self.deque.sema = self.mox.CreateMockAnything()
 
     def test_append(self):
         self.deque.sema.release()


### PR DESCRIPTION
Making TLS default to "on" is great for client-side, but on server-side you need at least a `certfile` to prevent the following error: `certfile must be specified for server-side operations`