### PR TITLE
Show but do not allow insecure auth mechanisms

### DIFF
--- a/slimta/edge/smtp.py
+++ b/slimta/edge/smtp.py
@@ -144,7 +144,7 @@ class SmtpSession(object):
     def AUTH(self, reply, creds):
         self._call_validator('auth', reply, creds)
         if reply.code == '235':
-            self.auth = creds.authcid
+            self.auth = (creds.authcid, creds.authzid)
 
     def RSET(self, reply):
         self.envelope = None

--- a/test/test_slimta_edge_smtp.py
+++ b/test/test_slimta_edge_smtp.py
@@ -62,7 +62,7 @@ class TestEdgeSmtp(unittest.TestCase, MoxTestBase):
         self.assertEqual('there', h.ehlo_as)
         self.assertTrue(h.extended_smtp)
         self.assertEqual('TLS', h.security)
-        self.assertEqual('testuser', h.auth)
+        self.assertEqual(('testuser', 'testzid'), h.auth)
         self.assertEqual('ESMTPSA', h.protocol)
 
     def test_mail_rcpt_data_rset(self):


### PR DESCRIPTION
This is consistent with the behavior described in [RFC 4954](https://tools.ietf.org/html/rfc4954#section-4).