### PR TITLE
Put the result of client PTR lookup in Envelope

### DIFF
--- a/slimta/edge/smtp.py
+++ b/slimta/edge/smtp.py
@@ -101,6 +101,7 @@ class SmtpSession(object):
         self.envelope = None
         self.ehlo_as = None
         self.auth = None
+        self._ptr_lookup = None
 
     def _call_validator(self, command, *args):
         method = 'handle_'+command
@@ -173,6 +174,8 @@ class SmtpSession(object):
         if reply.code != '250':
             return
 
+        if self._ptr_lookup is not None:
+            self.reverse_address = self._ptr_lookup.finish()
         self.envelope.client['ip'] = self.address[0]
         self.envelope.client['host'] = self.reverse_address
         self.envelope.client['name'] = self.ehlo_as

--- a/test/test_slimta_edge_smtp.py
+++ b/test/test_slimta_edge_smtp.py
@@ -90,16 +90,21 @@ class TestEdgeSmtp(unittest.TestCase, MoxTestBase):
             h.HAVE_DATA(reply, None, ValueError())
 
     def test_have_data(self):
+        class PtrLookup(object):
+            def finish(self, *args):
+                return 'localhost'
         env = Envelope()
         handoff = self.mox.CreateMockAnything()
         handoff(env).AndReturn([(env, 'testid')])
         self.mox.ReplayAll()
         h = SmtpSession(('127.0.0.1', 0), None, handoff)
         h.envelope = env
+        h._ptr_lookup = PtrLookup()
         reply = Reply('250')
         h.HAVE_DATA(reply, b'', None)
         self.assertEqual('250', reply.code)
         self.assertEqual('2.6.0 Message accepted for delivery', reply.message)
+        self.assertEqual('localhost', env.client['host'])
 
     def test_have_data_queueerror(self):
         env = Envelope()


### PR DESCRIPTION
When a client connects, a PtrLookup Greenlet is launched but
the result was never consumed. This commit puts the result
in Envelope.client['host'].