### PR TITLE
Add create_listeners helper function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='python-slimta',
-      version='4.0.1',
+      version='4.0.2',
       author='Ian Good',
       author_email='icgood@gmail.com',
       description='Lightweight, asynchronous SMTP libraries.',

--- a/slimta/util/__init__.py
+++ b/slimta/util/__init__.py
@@ -73,4 +73,61 @@ def create_connection_ipv4(address, timeout=None, source_address=None,
         raise socket.error('getaddrinfo returns an empty list')
 
 
+def create_listeners(address,
+                     family=socket.AF_UNSPEC,
+                     socktype=socket.SOCK_STREAM,
+                     proto=socket.IPPROTO_IP):
+    """Uses :func:`socket.getaddrinfo` to create listening sockets for
+    available socket parameters. For example, giving *address* as
+    ``('localhost', 80)`` on a system with IPv6 would return one socket bound
+    to ``127.0.0.1`` and one bound to ``::1`.
+
+    May also be used for ``socket.AF_UNIX`` with a file path to produce a
+    single unix domain socket listening on that path.
+
+    :param address: A ``(host, port)`` tuple to listen on.
+    :param family: the socket family, default ``AF_UNSPEC``.
+    :param socktype: the socket type, default ``SOCK_STREAM``.
+    :param proto: the socket protocol, default ``IPPROTO_IP``.
+
+    """
+    if family == socket.AF_UNIX:
+        sock = socket.socket(family, socktype, proto)
+        _init_socket(sock, address)
+        return [sock]
+    elif not isinstance(address, tuple) or len(address) != 2:
+        raise ValueError(address)
+    flags = socket.AI_PASSIVE
+    host, port = address
+    listeners = []
+    last_exc = None
+    for res in socket.getaddrinfo(host, port, family, socktype, proto, flags):
+        fam, typ, prt, _, sockaddr = res
+        try:
+            sock = socket.socket(fam, typ, prt)
+            _init_socket(sock, sockaddr)
+        except socket.error as exc:
+            last_exc = exc
+        else:
+            listeners.append(sock)
+    if last_exc and not listeners:
+        raise last_exc
+    return listeners
+
+
+def _init_socket(sock, sockaddr):
+    try:
+        sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+    except socket.error as exc:
+        pass
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    except socket.error as exc:
+        pass
+    sock.setblocking(0)
+    sock.bind(sockaddr)
+    if sock.type != socket.SOCK_DGRAM:
+        sock.listen(socket.SOMAXCONN)
+
+
 # vim:et:fdm=marker:sts=4:sw=4:ts=4

--- a/test/test_slimta_util.py
+++ b/test/test_slimta_util.py
@@ -11,7 +11,6 @@ class TestIPv4SocketCreator(MoxTestBase):
         super(TestIPv4SocketCreator, self).setUp()
         self.mox.StubOutWithMock(socket, 'create_connection')
         self.mox.StubOutWithMock(socket, 'getaddrinfo')
-        self.getaddrinfo = self.mox.CreateMock(socket.getaddrinfo)
         self.socket_creator = util.build_ipv4_socket_creator([25])
 
     def test_other_port(self):
@@ -39,6 +38,50 @@ class TestIPv4SocketCreator(MoxTestBase):
         self.mox.ReplayAll()
         with self.assertRaises(socket.error):
             self.socket_creator(('host', 25), 'timeout', 'source')
+
+
+class TestCreateListeners(MoxTestBase):
+
+    def setUp(self):
+        super(TestCreateListeners, self).setUp()
+        self.mox.StubOutWithMock(socket, 'getaddrinfo')
+        self.mox.StubOutWithMock(socket, 'socket')
+        self.sock = self.mox.CreateMockAnything()
+
+    def test_unix_socket(self):
+        socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, socket.IPPROTO_IP).AndReturn(self.sock)
+        self.sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.setblocking(0)
+        self.sock.bind('/path/to/sock')
+        self.sock.listen(socket.SOMAXCONN)
+        self.mox.ReplayAll()
+        listeners = util.create_listeners('/path/to/sock', socket.AF_UNIX)
+        self.assertEqual([self.sock], listeners)
+
+    def test_valueerror(self):
+        self.mox.ReplayAll()
+        with self.assertRaises(ValueError):
+            util.create_listeners('bad')
+
+    def test_successful(self):
+        socket.getaddrinfo('host', 25, socket.AF_UNSPEC, socket.SOCK_STREAM, socket.IPPROTO_IP, socket.AI_PASSIVE).AndReturn([(11, 12, 13, None, 'sockaddr')])
+        socket.socket(11, 12, 13).AndReturn(self.sock)
+        self.sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.setblocking(0)
+        self.sock.bind('sockaddr')
+        self.sock.listen(socket.SOMAXCONN)
+        self.mox.ReplayAll()
+        listeners = util.create_listeners(('host', 25))
+        self.assertEqual([self.sock], listeners)
+
+    def test_socket_error(self):
+        socket.getaddrinfo('host', 25, socket.AF_UNSPEC, socket.SOCK_STREAM, socket.IPPROTO_IP, socket.AI_PASSIVE).AndReturn([(11, 12, 13, None, 'sockaddr')])
+        socket.socket(11, 12, 13).AndRaise(socket.error)
+        self.mox.ReplayAll()
+        with self.assertRaises(socket.error):
+            util.create_listeners(('host', 25))
 
 
 # vim:et:fdm=marker:sts=4:sw=4:ts=4


### PR DESCRIPTION
Creates listening socket(s) bound to a given address. Useful for IPv4/6 compatibility.