### PR TITLE
Make LMTP client return successful results as well

### DIFF
--- a/slimta/relay/smtp/lmtpclient.py
+++ b/slimta/relay/smtp/lmtpclient.py
@@ -63,6 +63,8 @@ class LmtpRelayClient(SmtpRelayClient):
             if reply.is_error():
                 rcpt_results[rcpt] = SmtpRelayError.factory(reply)
                 had_errors = True
+            else:
+                rcpt_results[rcpt] = reply
         result.set(rcpt_results)
         if had_errors:
             self._rset()


### PR DESCRIPTION
Not sure if there's a reason why the LMTP client was returning RelayErrors for failed deliveries but nothing for successful ones.
Since the LMTP servers I work with actually send back a 250 reply on successful delivery, I'm assuming it is valid.

This small fix makes sure they're propagated back to the relay.