### PR TITLE
Some SMTP Server are answering with AUTH=PLAIN and not AUTH PLAIN

### DIFF
--- a/slimta/smtp/client.py
+++ b/slimta/smtp/client.py
@@ -270,7 +270,7 @@ class Client(object):
             return unknown_command
         auth_ext = self.extensions.getparam('AUTH')
         assert auth_ext is not None
-        advertised = [self._encode(mech_name)
+        advertised = [self._encode(mech_name).strip(b'=')
                       for mech_name in auth_ext.split()]
         auth = AuthSession(SASLAuth.named(advertised), self.io)
         if not mechanism and auth.client_mechanisms:


### PR DESCRIPTION
Some SMTP Server are answering with AUTH=PLAIN which causes =PLAIN not to be recognized as auth mechanism, so we need to strip '='.