### PR TITLE
Implement SNI callback

### DIFF
--- a/slimta/smtp/io.py
+++ b/slimta/smtp/io.py
@@ -67,6 +67,9 @@ class IO(object):
     def encrypted(self):
         return isinstance(self.socket, SSLSocket)
 
+    def _sni_callback(self, socket, server_name, context):
+        context.server_hostname = server_name
+
     def close(self):
         log.close(self.socket)
         if self.encrypted:
@@ -117,6 +120,7 @@ class IO(object):
     def encrypt_socket_server(self, context):
         log.encrypt(self.socket, context)
         try:
+            context.sni_callback = self._sni_callback
             self.socket = context.wrap_socket(self.socket, server_side=True)
             return True
         except SSLError as exc:


### PR DESCRIPTION
Set server_hostname for inbound (server side) SSLContext using SNI callback.

Can be used in tls2 handler like this:

```def handle_tls2(self, ssl_socket):
    print(ssl_socket.context.server_hostname)
```

If no SNI is available, server_hostname will remain None, no exceptions will be raised.